### PR TITLE
Add delegate method for did begin & end editing

### DIFF
--- a/Example/PinEntryView/ViewController.swift
+++ b/Example/PinEntryView/ViewController.swift
@@ -61,6 +61,10 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: PinEntryViewDelegate {
+    func pinEntryViewDidBeginEditing(_ view: PinEntryView) {
+        // Perform any custom action when editing starts
+    }
+    
     func pinEntryView(_ view: PinEntryView, didFinishEditing pin: String) {
         print("User finished editing PIN: \(pin)")
         view.resignFirstResponder()

--- a/Example/PinEntryView/ViewController.swift
+++ b/Example/PinEntryView/ViewController.swift
@@ -65,6 +65,10 @@ extension ViewController: PinEntryViewDelegate {
         // Perform any custom action when editing starts
     }
     
+    func pinEntryViewDidEndEditing(_ view: PinEntryView) {
+        // Perform any custom action when editing ends
+    }
+    
     func pinEntryView(_ view: PinEntryView, didFinishEditing pin: String) {
         print("User finished editing PIN: \(pin)")
         view.resignFirstResponder()

--- a/PinEntryView/Classes/PinEntryView.swift
+++ b/PinEntryView/Classes/PinEntryView.swift
@@ -17,6 +17,9 @@ public protocol PinEntryViewDelegate: class {
     
     /** Called when the user begins editing the PinEntryView */
     func pinEntryViewDidBeginEditing(_ view: PinEntryView)
+    
+    /** Called when the user ends editing the PinEntryView */
+    func pinEntryViewDidEndEditing(_ view: PinEntryView)
 }
 
 @IBDesignable public class PinEntryView: UIView {
@@ -220,6 +223,7 @@ extension PinEntryView: UITextFieldDelegate {
     public func textFieldDidEndEditing(_ textField: UITextField) {
         // Remove any focussed state
         updateButtonStates()
+        delegate?.pinEntryViewDidEndEditing(self)
     }
 }
 

--- a/PinEntryView/Classes/PinEntryView.swift
+++ b/PinEntryView/Classes/PinEntryView.swift
@@ -14,6 +14,9 @@ public protocol PinEntryViewDelegate: class {
     
     /** Called when the user taps the return key on the keyboard. */
     func pinEntryViewDidTapKeyboardReturnKey(_ view: PinEntryView)
+    
+    /** Called when the user begins editing the PinEntryView */
+    func pinEntryViewDidBeginEditing(_ view: PinEntryView)
 }
 
 @IBDesignable public class PinEntryView: UIView {
@@ -211,6 +214,7 @@ extension PinEntryView: UITextFieldDelegate {
     public func textFieldDidBeginEditing(_ textField: UITextField) {
         // Set the focussed state
         updateButtonStates()
+        delegate?.pinEntryViewDidBeginEditing(self)
     }
     
     public func textFieldDidEndEditing(_ textField: UITextField) {


### PR DESCRIPTION
# Details
This PR adds a couple new `PinEntryViewDelegate` method, `pinEntryViewDidBeginEditing(_:)` & `pinEntryViewDidEndEditing(_:)`, which will allow for the user to easily do custom actions when the `PinEntryView` begins & ends editing.

# Things to note
This will cause breaking changes because all `PinEntryViewDelegate` methods are required to be implemented. However, this is as simple as declaring the functions, no other work is needed.

This does not break existing functionality of the `PinEntryView` or the UX of this view.